### PR TITLE
Do not load unused Benchmark module

### DIFF
--- a/t/71_name_scheme.t
+++ b/t/71_name_scheme.t
@@ -3,7 +3,6 @@
 use v5.12;
 use warnings;
 use Test::More tests => 62;
-use Benchmark;
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Graphics::Toolkit::Color::Space::Util ':all';
 


### PR DESCRIPTION
The module was loaded in a test but no subroutine it expors was called. This patch removes this useless dependency.